### PR TITLE
Change spacing in search screen to show search by nearby location

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -63,9 +63,10 @@
         android:id="@+id/pbLoading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="62dp"
         android:visibility="invisible"
-        android:layout_marginTop="125dp"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/btnSearch" />
 
@@ -75,7 +76,7 @@
         android:layout_height="wrap_content"
         android:text="Don't have a location in mind?"
         android:textColor="@color/blue_1"
-        android:layout_marginTop="125dp"
+        android:layout_marginTop="62dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/pbLoading" />


### PR DESCRIPTION
The search by nearby location section was not being shown on the search screen so I changed the spacing to fit it on the screen.